### PR TITLE
cpp code highlighting issue (#27)

### DIFF
--- a/docs/advanced-mouse.md
+++ b/docs/advanced-mouse.md
@@ -11,20 +11,20 @@ cvui has its own mouse API to track mouse clicks and cursor position, for instan
 
 You can query the position of the mouse cursor any moment by calling `cvui::mouse()`, which returns a `cv::Point`:
 
-{% highlight c++ %}
+```cpp
 cv::Point mouse(const cv::String& theWindowName = "")
-{% endhighlight %}
+```
 
 Usage example:
 
-{% highlight c++ %}
+```cpp
 // Save the mouse cursor to a point object
 cv::Point cursor = cvui::mouse();
 std::cout << "x: " << cursor.x << " y: " << cursor.y << std::endl;
 
 // or access the position directly
 std::cout << "x: " << cvui::mouse().x << " y: " << cvui::mouse().y << std::endl;
-{% endhighlight %}
+```
 
 Calls to `cvui::mouse()` follow the cvui philosophy of always returning current information, so you don't have to listen to mouse events, for instance. Just call `cvui::mouse()` and you get the most up-to-date position of the mouse cursor.
 
@@ -32,9 +32,9 @@ Calls to `cvui::mouse()` follow the cvui philosophy of always returning current 
 
 You can query the state of the mouse, e.g. clicks, by calling `cvui::mouse(int)`, whose signature is:
 
-{% highlight c++ %}
+```cpp
 bool mouse(int theQuery)
-{% endhighlight %}
+```
 
 The parameter `theQuery` is an integer that specifies your query. Available queries are:
 
@@ -47,19 +47,19 @@ The parameter `theQuery` is an integer that specifies your query. Available quer
 
 Below is an example that shows a message when any mouse button is pressed:
 
-{% highlight c++ %}
+```cpp
 if (cvui::mouse(cvui::DOWN)) {
 	std::cout << "Any mouse button just went down." << std::endl;
 }
-{% endhighlight %}
+```
 
 Below is an example that shows a message only when any mouse button is clicked (pressed then released):
 
-{% highlight c++ %}
+```cpp
 if (cvui::mouse(cvui::CLICK)) {
 	std::cout << "A mouse click just happened." << std::endl;
 }
-{% endhighlight %}
+```
 
 ## Check mouse buttons individually
 
@@ -67,9 +67,9 @@ You can also query the state of a particular mouse button, e.g. react to clicks 
 
 Specific mouse buttons can be queried via `cvui::mouse(int, int)`, whose signature is:
 
-{% highlight c++ %}
+```cpp
 bool mouse(int theButton, int theQuery)
-{% endhighlight %}
+```
 
 The parameter `theButton` allows you to specify which mouse button you want to query. Available buttons are `cvui::LEFT_BUTTON`, `cvui::MIDDLE_BUTTON` and `cvui::RIGHT_BUTTON`.
 
@@ -77,19 +77,19 @@ The function `cvui::mouse(int theButton, int theQuery)` works exactly as `cvui::
 
 Below is an example that prints a message when the left mouse button is pressed:
 
-{% highlight c++ %}
+```cpp
 if (cvui::mouse(cvui::LEFT_BUTTON, cvui::DOWN)) {
 	std::cout << "Left mouse button just went down." << std::endl;
 }
-{% endhighlight %}
+```
 
 Here is another example that shows a message only when the left mouse button is clicked (pressed then released):
 
-{% highlight c++ %}
+```cpp
 if (cvui::mouse(cvui::LEFT_BUTTON, cvui::CLICK)) {
 	std::cout << "Left mouse button click just happened." << std::endl;
 }
-{% endhighlight %}
+```
 
 ## Learn more
 

--- a/docs/advanced-multiple-windows.md
+++ b/docs/advanced-multiple-windows.md
@@ -13,7 +13,7 @@ cvui uses OpenCV `cv::setMouseCallback()` to monitor interactions on each window
 
 The easiest way is to let cvui create the windows for you in `cvui::init()`. Below is an example where `cvui::init()` is called with an array of window names, so cvui will create the windows automatically:
 
-{% highlight c++ %}
+```cpp
 #define WINDOW1_NAME "Window 1"
 #define WINDOW2_NAME "Windows 2"
 #define WINDOW3_NAME "Windows 3"
@@ -33,7 +33,7 @@ int main() {
     // your logic here
   }
 }
-{% endhighlight %}
+```
 
 ## 1.1 (Optional) Create your own windows
 
@@ -41,7 +41,7 @@ If you want to create the windows youself, ensure you create them using `cv::nam
 
 When initializing cvui using `cvui::init()`, you still need to inform the name of a window (which will be the default window), then call `cvui::watch()` for each subsequent window to be monitored by cvui:
 
-{% highlight c++ %}
+```cpp
 #define WINDOW1_NAME "Window 1"
 #define WINDOW2_NAME "Windows 2"
 #define WINDOW3_NAME "Windows 3"
@@ -74,7 +74,7 @@ int main() {
     // your logic here
   }
 }
-{% endhighlight %}
+```
 
 ## 2. Tell cvui about the window, then render it
 
@@ -82,7 +82,7 @@ When using cvui components with multiple windows, you need to inform cvui which 
 
 The example below shows how to render a few components in two different window, e.g. `"window1"` and `"window2"`, assuming those windows were already created and cvui properly initialized before:
 
-{% highlight c++ %}
+```cpp
 // Create a frame for the windows
 cv::Mat frame = cv::Mat(200, 500, CV_8UC3);
 
@@ -93,7 +93,7 @@ cvui::imshow("window1", frame);              // update cvui interactions on wind
 cvui::context("window1");                     // Inform cvui that the components to be rendered from now one belong to "window2"
 cvui::text(frame, 5, 5, "Hey, window2");
 cvui::imshow("window1", frame);               // update cvui interactions on window "window2"
-{% endhighlight %}
+```
 
 ## 2.1 (Optional) Fine control update and show
 
@@ -105,7 +105,7 @@ In that case, you enclose all cvui component calls between the pair `cvui::conte
 
 The example below shows how to separately update and render a few components in two different window, e.g. `"window1"` and `"window2"`, assuming those windows were already created and cvui properly initialized before:
 
-{% highlight c++ %}
+```cpp
 // Create a frame for this window and fill it with a nice color
 cv::Mat frame = cv::Mat(200, 500, CV_8UC3);
 
@@ -123,4 +123,4 @@ cvui::update("window1");                      // update cvui interactions on win
 // Show the content of window "window2" on the screen
 cvui::imshow("window2", frame);
 
-{% endhighlight %}
+```

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -7,9 +7,9 @@ title: button
 
 `cvui::button()` renders a button. The common signature of a button function is:
 
-{% highlight c++ %}
+```cpp
 bool button(cv::Mat& theWhere, int theX, int theY, const cv::String& theLabel)
-{% endhighlight %}
+```
 
 where `theWhere` is the image/frame where the button will be rendered, `theX` is the position X, `theY` is the position Y, and `theLabel` is the text displayed inside the button.
 
@@ -19,24 +19,24 @@ All button functions return `true` if the user clicked the button, or `false` ot
 
 Button width will auto-adjust based on the size of its label. Below is an example of a button with auto-adjusted width (shown in Figure 1):
 
-{% highlight c++ %}
+```cpp
 // cv::Mat frame, x, y, label
 if (cvui::button(frame, 100, 40, "Button")) {
     // button was clicked
 }
-{% endhighlight %}
+```
 
 ![Button]({{ site.url }}/img/button.png)
 <p class="img-caption">Figure 1: Button with auto-adjusted width.</p>
 
 It is also possible to specify the width and height of a button (shown in Figure 2):
 
-{% highlight c++ %}
+```cpp
 // cv::Mat frame, x, y, width, height, label
 if (cvui::button(frame, 100, 40, 100, 30, "Button")) {
     // button was clicked
 }
-{% endhighlight %}
+```
 
 ![Button]({{ site.url }}/img/button-width.png)
 <p class="img-caption">Figure 2: Button with custom width.</p>
@@ -45,7 +45,7 @@ if (cvui::button(frame, 100, 40, 100, 30, "Button")) {
 
 You can display a button whose graphics are images (`cv::Mat`). Such button accepts three images to describe its states, which are _idle_ (no mouse interaction), _over_ (mouse cursor is over the button) and _down_ (mouse clicked the button):
 
-{% highlight c++ %}
+```cpp
 bool button (
     cv::Mat& theWhere,
     int theX,
@@ -54,11 +54,11 @@ bool button (
     cv::Mat& theOver,
     cv::Mat& theDown
 );
-{% endhighlight %}
+```
 
 The button size will be defined by the width and height of the images. E.g.:
 
-{% highlight c++ %}
+```cpp
 cv::Mat idle = cv::imread("btn_idle_state.jpg", cv::IMREAD_COLOR);
 cv::Mat over = cv::imread("btn_over_state.jpg", cv::IMREAD_COLOR);
 cv::Mat down = cv::imread("btn_down_state.jpg", cv::IMREAD_COLOR);
@@ -67,7 +67,7 @@ cv::Mat down = cv::imread("btn_down_state.jpg", cv::IMREAD_COLOR);
 if (cvui::button(frame, 200, 80, idle, over, down)) {
     // button was clicked
 }
-{% endhighlight %}
+```
 
 ## Learn more
 

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -7,7 +7,7 @@ title: checkbox
 
 `cvui::checkbox()` renders a checkbox. The signature of the function is:
 
-{% highlight c++ %}
+```cpp
 bool checkbox (
     cv::Mat& theWhere,
     int theX,
@@ -16,7 +16,7 @@ bool checkbox (
     bool *theState,
     unsigned int theColor = 0xCECECE
 )
-{% endhighlight %}
+```
 
 where `theWhere` is the image/frame where the image will be rendered, `theX` is the position X, `theY` is the position Y, `theLabel` is text displayed besides the clickable checkbox square, `theState` describes the current state of the checkbox (`true` means the checkbox is checked) and `theColor` is color of the label in the format `0xRRGGBB`, e.g. `0xff0000` for red.
 
@@ -24,10 +24,10 @@ where `theWhere` is the image/frame where the image will be rendered, `theX` is 
 
 Below is an example showing a checkbox. The result on the screen is shown in Figure 1.
 
-{% highlight c++ %}
+```cpp
 bool checked = false;
 cvui::checkbox(frame, 90, 50, "Checkbox label", &checked);
-{% endhighlight %}
+```
 
 ![Checkbox]({{ site.url }}/img/checkbox.png)
 <p class="img-caption">Figure 1: checkbox component.</p>

--- a/docs/components/counter.md
+++ b/docs/components/counter.md
@@ -7,7 +7,7 @@ title: counter
 
 `cvui::counter()` renders a counter for integer (or double) values that users can increase/decrease by clicking up and down arrows. The signature of the functions are:
 
-{% highlight c++ %}
+```cpp
 int counter (
     cv::Mat& theWhere,
     int theX,
@@ -16,9 +16,9 @@ int counter (
     int theStep = 1,
     const char *theFormat = "%d"
 )
-{% endhighlight %}
+```
 
-{% highlight c++ %}
+```cpp
 double counter (
     cv::Mat& theWhere,
     int theX,
@@ -27,7 +27,7 @@ double counter (
     double theStep = 0.5,
     const char *theFormat = "%.2f"
 )
-{% endhighlight %}
+```
 
 where `theWhere` is the image/frame where the image will be rendered, `theX` is the position X, `theY` is the position Y, `theValue` is the current value of the counter, `theStep` is the amount that should be increased/decreased when the user interacts with the counter buttons, and `theFormat` is how the value of the counter should be presented, as it was printed by `stdio's printf()`. E.g. `"%d"` means the value will be displayed as an integer, `"%0d"` integer with one leading zero, etc.
 
@@ -35,10 +35,10 @@ where `theWhere` is the image/frame where the image will be rendered, `theX` is 
 
 Below is an example showing a counter. The result on the screen is shown in Figure 1.
 
-{% highlight c++ %}
+```cpp
 int count = 2;
 cvui::counter(frame, 90, 50, &count);
-{% endhighlight %}
+```
 
 ![Counter]({{ site.url }}/img/counter.png)
 <p class="img-caption">Figure 1: counter component.</p>

--- a/docs/components/iarea.md
+++ b/docs/components/iarea.md
@@ -7,9 +7,9 @@ title: iarea
 
 `cvui::iarea()` creates an interaction area that reports mouse cursor activity. The signature of the function is:
 
-{% highlight c++ %}
+```cpp
 int iarea(int theX, int theY, int theWidth, int theHeight);
-{% endhighlight %}
+```
 
 where `theX` is the position X, `theY` is the position Y, `theWidth` is the width of the interaction area, and `theHeight` is the height of the interaction area.
 
@@ -23,7 +23,7 @@ where `theX` is the position X, `theY` is the position Y, `theWidth` is the widt
 
 Below is an example showing an interaction area and its interaction with the mouse cursor.
 
-{% highlight c++ %}
+```cpp
 int status = cvui::iarea(30, 70, 90, 100);
 
 // render a rectangle in the iarea, so we can see it
@@ -35,7 +35,7 @@ switch (status) {
   case cvui::OVER:   cvui::printf(frame, 240, 70, "Mouse is: OVER"); break;
   case cvui::OUT:    cvui::printf(frame, 240, 70, "Mouse is: OUT"); break;
 }
-{% endhighlight %}
+```
 
 ![iarea]({{ site.url }}/img/iarea.gif)
 <p class="img-caption">Figure 1: tracked interaction within an interaction area (iarea).</p>

--- a/docs/components/image.md
+++ b/docs/components/image.md
@@ -7,18 +7,18 @@ title: image
 
 `cvui::image()` renders an image, i.e. `cv::Mat`. The signature of the function is:
 
-{% highlight c++ %}
+```cpp
 void image(cv::Mat& theWhere, int theX, int theY, cv::Mat& theImage);
-{% endhighlight %}
+```
 
 where `theWhere` is the image/frame where the image will be rendered, `theX` is the position X, `theY` is the position Y, and `theImage` is an image to be rendered in the specified destination.
 
 Below is an example showing an image being loaded then displayed using `cvui::image()`. The result on the screen is shown in Figure 1.
 
-{% highlight c++ %}
+```cpp
 cv::Mat lena_face = cv::imread("lena_face.jpg", cv::IMREAD_COLOR);
 cvui::image(frame, 10, 10, lena_face);
-{% endhighlight %}
+```
 
 ![Image]({{ site.url }}/img/image.png)
 <p class="img-caption">Figure 1: image <code>lena_face.jpg</code> displayed on the screen.</p>

--- a/docs/components/printf.md
+++ b/docs/components/printf.md
@@ -7,18 +7,18 @@ title: printf
 
 `cvui::printf()` renders a piece of text that can be formatted using C `printf()` style. The signature of the function is:
 
-{% highlight c++ %}
+```cpp
 void printf(cv::Mat& theWhere, int theX, int theY, const char *theFmt, ...);
-{% endhighlight %}
+```
 
 where `theWhere` is the image/frame where the image will be rendered, `theX` is the position X, `theY` is the position Y, `theFmt` is the formating string as it would be supplied for `stdio's printf()`, e.g. `"Text: %d and %f", 7, 3.1415`.
 
 `cvui::printf()` is used pretty much as C's `printf()` function. Below is an example of the component, whose result on the screen is shown in Figure 1.
 
-{% highlight c++ %}
+```cpp
 double value = 3.14;
 cvui::printf(frame, 90, 50, "value = %.2f", value);
-{% endhighlight %}
+```
 
 ![printf component]({{ site.url }}/img/printf.png)
 <p class="img-caption">Figure 1: printf component.</p>
@@ -27,7 +27,7 @@ cvui::printf(frame, 90, 50, "value = %.2f", value);
 
 It is possible to customize the size and color of the text produced by `cvui::printf()`. The following function signature can be used in that case:
 
-{% highlight c++ %}
+```cpp
 void printf (
     cv::Mat& theWhere,
     int theX,
@@ -37,16 +37,16 @@ void printf (
     const char *theFmt,
     ...
 );
-{% endhighlight %}
+```
 
 where `theWhere` is the image/frame where the image will be rendered, `theX` is the position X, `theY` is the position Y, `theFontScale` is the size of the text, `theColor` is the color of the text in the format `0xRRGGBB`, e.g. `0xff0000` for red, and `theFmt` is the formating string as it would be supplied for `stdio's printf()`, e.g. `"Text: %d and %f", 7, 3.1415`.
 
 Below is an example of a text with customized size and color. Result on the screen is shown in Figure 2.
 
-{% highlight c++ %}
+```cpp
 double value = 3.14;
 cvui::printf(frame, 90, 50, 0.8, 0x00ff00, "value = %.2f", value);
-{% endhighlight %}
+```
 
 ![printf with customized size and color]({{ site.url }}/img/printf-tweaked.png)
 <p class="img-caption">Figure 2: text with customized size and color.</p>

--- a/docs/components/rect.md
+++ b/docs/components/rect.md
@@ -7,7 +7,7 @@ title: rect
 
 `cvui::rect()` renders a rectangle, filled or not. The signature of the function is:
 
-{% highlight c++ %}
+```cpp
 void rect (
     cv::Mat& theWhere,
     int theX,
@@ -17,24 +17,24 @@ void rect (
     unsigned int theBorderColor,
     unsigned int theFillingColor = 0xff000000
 )
-{% endhighlight %}
+```
 
 where `theWhere` is the image/frame where the image will be rendered, `theX` is the position X, `theY` is the position Y, `theWidth` is the width of the rectangle, `theHeight` is the height of the rectangle, `theBorderColor` is the color of rectangle's border in the format `0xRRGGBB`, e.g. `0xff0000` for red, and `theFillingColor` is the color of rectangle's filling in the format `0xAARRGGBB`, e.g. `0x00ff0000` for red, `0xff000000` for transparent filling.
 
 Below is an example showing a rectangle with no filling color (transparent). The result on the screen is shown in Figure 1.
 
-{% highlight c++ %}
+```cpp
 cvui::rect(frame, 60, 10, 130, 90, 0xff0000);
-{% endhighlight %}
+```
 
 ![Rectangle with no filling]({{ site.url }}/img/rect.png)
 <p class="img-caption">Figure 1: rect component.</p>
 
 Rectangles can be filled with a solid color, as demonstrated below. Result on the screen shown in Figure 2.
 
-{% highlight c++ %}
+```cpp
 cvui::rect(frame, 60, 10, 130, 90, 0xff0000, 0x00ff00);
-{% endhighlight %}
+```
 
 ![Color-filled rectangle]({{ site.url }}/img/rect-filled.png)
 <p class="img-caption">Figure 2: rect component filled with a solid color.</p>

--- a/docs/components/sparkline.md
+++ b/docs/components/sparkline.md
@@ -7,7 +7,7 @@ title: sparkline
 
 `cvui::sparkline()` renders the values of a `std::vector<double>` as a sparkline. The signature of the function is:
 
-{% highlight c++ %}
+```cpp
 void sparkline (
     cv::Mat& theWhere,
     std::vector<double>& theValues,
@@ -17,7 +17,7 @@ void sparkline (
     int theHeight,
     unsigned int theColor = 0x00FF00
 )
-{% endhighlight %}
+```
 
 where `theWhere` is the image/frame where the image will be rendered, `theX` is the position X, `theY` is the position Y, `theWidth` is the width of the sparkline, `theHeight` is the height of the sparkline, and `theColor` is the color of sparkline in the format `0xRRGGBB`, e.g. `0xff0000` for red.
 
@@ -25,14 +25,14 @@ where `theWhere` is the image/frame where the image will be rendered, `theX` is 
 
 Below is an example showing a sparkline. The result on the screen is shown in Figure 1.
 
-{% highlight c++ %}
+```cpp
 std::vector<double> values;
 for (std::vector<double>::size_type i = 0; i < 30; i++) {
   values.push_back(rand() + 0.);
 }
 
 cvui::sparkline(frame, values, 10, 10, 280, 100);
-{% endhighlight %}
+```
 
 ![Sparkline]({{ site.url }}/img/sparkline.png)
 <p class="img-caption">Figure 1: sparkline component.</p>

--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -7,7 +7,7 @@ title: text
 
 `cvui::text()` renders a string. The signature of the function is:
 
-{% highlight c++ %}
+```cpp
 void text (
     cv::Mat& theWhere,
     int theX,
@@ -16,15 +16,15 @@ void text (
     double theFontScale = 0.4,
     unsigned int theColor = 0xCECECE
 )
-{% endhighlight %}
+```
 
 where `theWhere` is the image/frame where the image will be rendered, `theX` is the position X, `theY` is the position Y, `theText` is the text content, `theFontScale` is the size of the text, and `theColor` is color of the text in the format `0xRRGGBB`, e.g. `0xff0000` for red.
 
 Below is an example of the text component. The result on the screen is shown in Figure 1.
 
-{% highlight c++ %}
+```cpp
 cvui::text(frame, 90, 50, "Hello world");
-{% endhighlight %}
+```
 
 ![Text]({{ site.url }}/img/text.png)
 <p class="img-caption">Figure 1: text component.</p>

--- a/docs/components/trackbar.md
+++ b/docs/components/trackbar.md
@@ -7,7 +7,7 @@ title: trackbar
 
 `cvui::trackbar()` renders a trackbar for numeric values that users can increase/decrease by clicking and/or dragging the marker right or left. The signature of the function is:
 
-{% highlight c++ %}
+```cpp
 template <typename T>
 bool trackbar (
     cv::Mat& theWhere,
@@ -22,7 +22,7 @@ bool trackbar (
     unsigned int theOptions = 0,
     T theDiscreteStep = 1
 )
-{% endhighlight %}
+```
 
 where `theWhere` is the image/frame where the image will be rendered, `theX` is the position X, `theY` is the position Y, `theWidth` is the width of the trackbar, `theValue` is the current value of the trackbar, `theMin` is the minimum value allowed for the trackbar, `theMax` is the maximum value allowed for the trackbar.
 
@@ -34,10 +34,10 @@ The parameter `theValue`  will be modified when the user interacts with the trac
 
 Below is an example showing a trackbar. The result on the screen is shown in Figure 1.
 
-{% highlight c++ %}
+```cpp
 double value = 12.4;
 cvui::trackbar(frame, 40, 30, 220, &value, (double)10.0, (double)15.0);
-{% endhighlight %}
+```
 
 ![Trackbar]({{ site.url }}/img/trackbar.png)
 <p class="img-caption">Figure 1: trackbar component using double values.</p>

--- a/docs/components/window.md
+++ b/docs/components/window.md
@@ -7,7 +7,7 @@ title: window
 
 `cvui::window()` renders a window (a block with a title and a body). The signature of the function is:
 
-{% highlight c++ %}
+```cpp
 void window (
     cv::Mat& theWhere,
     int theX,
@@ -16,15 +16,15 @@ void window (
     int theHeight,
     const cv::String& theTitle
 )
-{% endhighlight %}
+```
 
 where `theWhere` is the image/frame where the image will be rendered, `theX` is the position X, `theY` is the position Y, `theWidth` is the width of the window, `theHeight` is the height of the window, and `theTitle` is the text displayed as the title of the window.
 
 Below is an example showing a window. The result on the screen is shown in Figure 1.
 
-{% highlight c++ %}
+```cpp
 cvui::window(frame, 60, 10, 130, 90, "Title");
-{% endhighlight %}
+```
 
 ![Window]({{ site.url }}/img/window.png)
 <p class="img-caption">Figure 1: window component.</p>

--- a/docs/layout-introduction.md
+++ b/docs/layout-introduction.md
@@ -9,7 +9,7 @@ One of the most annoying tasks when building UI is to calculate the position of 
 
 You create rows by using `beginRow()` and `endRow()`. Similarly you create columns by using `beginColumn()` and `endColumn()`. The signature of `cvui::begin*()` is:
 
-{% highlight c++ %}
+```cpp
 void begin{Row,Column} (
   cv::Mat &theWhere,
   int theX,
@@ -18,7 +18,7 @@ void begin{Row,Column} (
   int theHeight = -1,
   int thePadding = 0
 )
-{% endhighlight %}
+```
 
 Both `cvui::beginRow()` and `cvui::beginColumn()` require you to inform the frame where the row/column will be rendered and its `(x, y)` coordinate on the screen. Opitionally you can inform the width, height and padding of the row/column.
 
@@ -30,7 +30,7 @@ You can create a row/column in three steps: use `begin*()` to start a group (row
 
 Here is an example of a row:
 
-{% highlight c++ %}
+```cpp
 cv::Mat frame = cv::Mat(300, 800, CV_8UC3);
 
 // beginRow(cv::Mat, x, y)
@@ -41,7 +41,7 @@ cvui::beginRow(frame, 10, 20);
   cvui::button(100, 30, "Fixed");
   cvui::text("with text.");  
 cvui::endRow();
-{% endhighlight %}
+```
 
 The code above will produce the following on the screen:
 
@@ -56,7 +56,7 @@ Width and height of a row/column are `-1` by default, which means cvui will calc
 
 Padding of a row/column is `0` by defalut, which means components will be placed with no spacing between them. The parameter `thePadding` allows you to change the spacing of components in a row/column. Below is another row as example, however using `50` as padding:
 
-{% highlight c++ %}
+```cpp
 // beginRow(cv::Mat, x, y, width, height, padding)
 cvui::beginRow(frame, 10, 20, -1, -1, 50);
   cvui::text("This is another row");
@@ -65,7 +65,7 @@ cvui::beginRow(frame, 10, 20, -1, -1, 50);
   cvui::button(100, 30, "Fixed");
   cvui::text("with text.");  
 cvui::endRow();
-{% endhighlight %}
+```
 
 The result on the screen will be:
 
@@ -74,7 +74,7 @@ The result on the screen will be:
 
 You can create columns in the same fashion. Below is an example showing how to create three adjacent columns, which use different padding configurations.
 
-{% highlight c++ %}
+```cpp
 // cv::Mat, x, y, width, height, padding
 cvui::beginColumn(frame, 50, 50, 100, 200);
   cvui::text("Column 1 (no padding)");
@@ -105,7 +105,7 @@ cvui::beginColumn(frame, 550, 50, 100, 200);
   cvui::text("End of column 2 (40px below)");
 cvui::endColumn();
 
-{% endhighlight %}
+```
 
 ![Example of cvui::beginRow() and cvui::endRow() with padding]({{ site.url }}/img/columns-padding-spacing.png)
 <p class="img-caption">Figure 3: columns with different spacing configurations. Column #1: no padding. Column #2: padding of 10px. Column #3: no padding, but spaced using <code>cvui::space()</code>.</p>

--- a/docs/layout-nesting.md
+++ b/docs/layout-nesting.md
@@ -11,7 +11,7 @@ When a column or row is nested within another, it behaves like any ordinary comp
 
 Below is an example showing the general idea of nesting rows and columns:
 
-{% highlight c++ %}
+```cpp
 cv::Mat frame = cv::Mat(300, 800, CV_8UC3);
 
 // beginRow(cv::mat, x, y, width, height);
@@ -28,11 +28,11 @@ cvui::beginRow(frame, 10, 50, 100, 150);
     cvui::button("button1");
   cvui::endColumn();
 cvui::endRow();
-{% endhighlight %}
+```
 
 You could omit the width/height of (nested or not) rows/columns, so cvui will calculate its dimensions based on its components:
 
-{% highlight c++ %}
+```cpp
 // beginRow(cv::mat, x, y);
 cvui::beginRow(frame, 10, 50);
   cvui::beginColumn();
@@ -45,13 +45,13 @@ cvui::beginRow(frame, 10, 50);
     cvui::button("button1");
   cvui::endColumn();
 cvui::endRow();
-{% endhighlight %}
+```
 
 ## Example of row with nested columns
 
 Below is an example of a row whose components are texts, buttons and columns.
 
-{% highlight c++ %}
+```cpp
 // Define a row at position (10, 50) with width 100 and height 150.
 // beginRow(cv::mat, x, y, width, height, padding);
 cvui::beginRow(frame, 10, 50, 100, 150);
@@ -89,7 +89,7 @@ cvui::beginRow(frame, 10, 50, 100, 150);
   cvui::text("this is the ");
   cvui::text("end of the row!");
 cvui::endRow();
-{% endhighlight %}
+```
 
 The code above will produce the following on the screen:
 
@@ -102,7 +102,7 @@ Nested columns (and rows) behave like any other components. In this example, the
 
 Below is the same example as before, however the main row has a padding of `10px` and all rows/columns have automatically calculated dimensions:
 
-{% highlight c++ %}
+```cpp
 // beginRow(cv::mat, x, y, width, height, padding);
 cvui::beginRow(frame, 10, 50, -1, -1, 10);
   cvui::text("Row starts");
@@ -133,7 +133,7 @@ cvui::beginRow(frame, 10, 50, -1, -1, 10);
   cvui::text("this is the ");
   cvui::text("end of the row!");
 cvui::endRow();
-{% endhighlight %}
+```
 
 The code above will produce the following on the screen:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,15 +11,15 @@ Below are a few steps you need to perform to work with cvui.
 
 Download the [latest release](https://github.com/Dovyski/cvui/releases/latest) and place `cvui.h` along with the files of your project. Include `cvui.h` in one of your C++ files as follows:
 
-{% highlight c++ %}
+```cpp
 #define CVUI_IMPLEMENTATION
 #include "cvui.h"
-{% endhighlight %}
+```
 
 <div class="notice--warning">
 <strong>IMPORTANT:</strong> if you are using <code>cvui.h</code> in multiple files, e.g. different layout classes, you need to use <code>#define CVUI_IMPLEMENTATION</code> in <strong>one (and only one) of your C++ files</strong>. All other files should include <code>cvui.h</code> without <code>#define CVUI_IMPLEMENTATION</code>. E.g:
 
-{% highlight c++ %}
+```cpp
 // File: main.cpp
 #define CVUI_IMPLEMENTATION      <-- CVUI_IMPLEMENTATION defined in one (and only one) C++ source file.
 #include "cvui.h"
@@ -35,7 +35,7 @@ Download the [latest release](https://github.com/Dovyski/cvui/releases/latest) a
 #include "cvui.h"
 // (...)
 /////////////////////////////////////////////
-{% endhighlight %}
+```
 </div>
 
 <div class="notice--info"><strong>Tip:</strong> check the <a href="https://github.com/Dovyski/cvui/tree/master/example/src/multiple-files">multiple-files</a> example to learn more about the use of cvui in projects with multiple files that include <code>cvui.h</code>.</div>
@@ -44,7 +44,7 @@ Download the [latest release](https://github.com/Dovyski/cvui/releases/latest) a
 
 Before using cvui, you need to call `cvui::init()` to initialize it. The easiest way is to initialize cvui and tell it to create any OpenCV window that will be used. Below is an example where cvui is initialized and a window is created:
 
-{% highlight c++ %}
+```cpp
 #include <opencv2/opencv.hpp>
 #define CVUI_IMPLEMENTATION
 #include "cvui.h"
@@ -65,7 +65,7 @@ int main() {
 
   return 0;
 }
-{% endhighlight %}
+```
 
 <div class="notice--info"><strong>Tip:</strong> if you need to use cvui with multiple windows, or you want more control over the process of creating windows, check the <a href="{{ site.url }}/advanced-multiple-windows">Multiple OpenCV windows</a> page and the <a href="https://github.com/Dovyski/cvui/tree/master/example/src/multiple-windows">multiple-windows</a> and <a href="https://github.com/Dovyski/cvui/tree/master/example/src/multiple-windows-complex">multiple-windows-complex</a> examples.</div>
 
@@ -73,7 +73,7 @@ int main() {
 
 All cvui components are rendered to a `cv::Mat`. Below is an example showing how to render a `"Hello world"` message on a `cv::Mat` named `frame`:
 
-{% highlight c++ %}
+```cpp
 #include <opencv2/opencv.hpp>
 #define CVUI_IMPLEMENTATION
 #include "cvui.h"
@@ -100,7 +100,7 @@ int main() {
 
   return 0;
 }
-{% endhighlight %}
+```
 
 ## 3. Show (window) content
 
@@ -130,13 +130,13 @@ int main() {
   }
   return 0;
 }
-{% endhighlight %}
+```
 
 When you use `cvui::imshow()` instead of `cv::imshow()`, cvui will not only show the content, but update its internal structures to ensure all UI interactions work.
 
 If you want to use `cv::imshow()`, you must call `cvui::update()` before `cv::imshow()` and after you are finished invoking cvui components, so cvui can perform its internal processing to handle mouse interactions. E.g.
 
-{% highlight c++ %}
+```cpp
 #include <opencv2/opencv.hpp>
 #define CVUI_IMPLEMENTATION
 #include "cvui.h"
@@ -164,7 +164,7 @@ int main() {
 
   return 0;
 }
-{% endhighlight %}
+```
 
 ## (Optional) 4. Disable cvui compilation messages
 
@@ -175,13 +175,13 @@ The compilation process of cvui will produce a few console messages to help deve
 
 You can disable such compilation messages by defining `CVUI_DISABLE_COMPILATION_NOTICES` before including `cvui.h`. E.g.:
 
-{% highlight c++ %}
+```cpp
 #include <opencv2/opencv.hpp>
 
 #define CVUI_DISABLE_COMPILATION_NOTICES
 #define CVUI_IMPLEMENTATION
 #include "cvui.h"
-{% endhighlight %}
+```
 
 ## Learn more
 


### PR DESCRIPTION
``{% highlight c++ %} .... {% endhighlight %}`` not working, for all the .md files in the docs, so replaced it with ```` ```cpp....``` ````