### PR TITLE
Drop BETA label in docs/_config.yml

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,3 @@
 url: https://dovyski.github.io/cvui
-cvui_version: 2.5.0-BETA
+cvui_version: 2.5.0
 permalink: pretty


### PR DESCRIPTION
show correct version on https://dovyski.github.io/cvui/ web page.
