### PR TITLE
Fix typo for full opacity

### DIFF
--- a/cvui.h
+++ b/cvui.h
@@ -2065,7 +2065,7 @@ namespace render
 		bool aHasFilling = aFilling[3] != 0xff;
 
 		if (aHasFilling) {
-			if (aFilling[3] == 0xff) {
+			if (aFilling[3] == 0x00) {
 				// full opacity
 				cv::rectangle(theBlock.where, thePos, aFilling, CVUI_FILLED, CVUI_ANTIALISED);
 			}


### PR DESCRIPTION
0xff means full-transparency (implying aHasFilling->false). 0x00 means no transparency (full-opacity).