### PR TITLE
Fixes  #81

### DIFF
--- a/cvui.h
+++ b/cvui.h
@@ -2105,7 +2105,6 @@ namespace render
 
 		// Then the filling.
 		theContent.x++; theContent.y++; theContent.width -= 2; theContent.height -= 2;
-		cv::rectangle(aOverlay, theContent, cv::Scalar(0x31, 0x31, 0x31), CVUI_FILLED);
 
 		if (aTransparecy) {
 			theBlock.where.copyTo(aOverlay);


### PR DESCRIPTION
Fixes bug #81. This line is not necessary
`cv::rectangle(aOverlay, theContent, cv::Scalar(0x31, 0x31, 0x31), CVUI_FILLED);`,
as it is correctly used in [here](https://github.com/Dovyski/cvui/blob/39185b38d18e91510e6f1fba40e6868f1104df45/cvui.h#L2112)
