### PR TITLE
fixed small bug about trackbar in on-image.py

### DIFF
--- a/example/src/on-image/on-image.py
+++ b/example/src/on-image/on-image.py
@@ -80,10 +80,10 @@ def main():
 
 		if (rgbModified):
 			b,g,r = cv2.split(lena)
-			b = b * rgb[2][0]
-			g = g * rgb[1][0]
-			r = r * rgb[0][0]
-			cv2.merge((b,g,r), doubleBuffer)
+			b = (b * rgb[2][0]).astype(np.float)
+			g = (g * rgb[1][0]).astype(np.float)
+			r = (r * rgb[0][0]).astype(np.float)
+			doubleBuffer = cv2.merge((b,g,r), doubleBuffer)
 		cvui.endColumn()
 
 		# HSV
@@ -107,10 +107,11 @@ def main():
 		if hsvModified:
 			hsvMat = cv2.cvtColor(lena, cv2.COLOR_BGR2HSV)
 			h,s,v = cv2.split(hsvMat)
-			h = h * hsv[0][0]
-			s = s * hsv[1][0]
-			v = v * hsv[2][0]
-			cv2.merge((h,s,v), hsvMat)
+			h = (h * hsv[0][0]).astype(np.float)
+			s = (s * hsv[1][0]).astype(np.float)
+			v = (v * hsv[2][0]).astype(np.float)
+			hsvMat = cv2.merge((h,s,v), hsvMat)
+			hsvMat = np.uint8(hsvMat)
 			doubleBuffer = cv2.cvtColor(hsvMat, cv2.COLOR_HSV2BGR)
 
 		cvui.endColumn()


### PR DESCRIPTION
Hello, Mr. Dovyski ! 
I'm a regular user of your OSS.
when I use your sample code, somethig went to wrong in my environment.
so, I tried to fix several lines.

**My environment** 
・windows10
・OpenCV 3.4.7
・Python 3.6.8

**Fixed section**
cvui/example/src/on-image/on-image.py

**Problem**
・Both of trackbar doesn't work well. The input image doesn't change colors itself. 
・When I click trackbar of "R" or "H", occurred an error by converting uint8 to Incompatible type (float64). (error massage: error: ((-215:Assertion failed) mv[i].size == mv[0].size && mv[i].depth() == depth in function 'cv::merge')

**Solution** 
・I added a variable to receive return value of merge method.
・I added ".astype(np.float)" 

Will you please point out any mistakes to me in this code, because this is my first pull request.
Thank you!