### PR TITLE
Double Click , and mouse wheel support, bug fix drawing image with different color space then main window

### DIFF
--- a/EnhancedWindow.h
+++ b/EnhancedWindow.h
@@ -71,7 +71,8 @@ public:
 		if (mMinimizable && cvui::button(frame, mX + mWidth - scaledTitleHeight, mY + 1, scaledTitleHeight-1, scaledTitleHeight-1, mMinimized ? "+" : "-", mFontScale)) {
 			mMinimized = !mMinimized;
 		}
-		cvui::beginRow(frame, mX + std::lround(10*mFontScale/cvui::DEFAULT_FONT_SCALE), mY + std::lround(30*mFontScale/cvui::DEFAULT_FONT_SCALE), mWidth - scaledTitleHeight, mHeight - scaledTitleHeight);
+		//cvui::beginRow(frame, mX + std::lround(10*mFontScale/cvui::DEFAULT_FONT_SCALE), mY + std::lround(30*mFontScale/cvui::DEFAULT_FONT_SCALE), mWidth - scaledTitleHeight, mHeight - scaledTitleHeight);
+		cvui::beginRow(frame, mX,mY+ scaledTitleHeight, mWidth - scaledTitleHeight, mHeight - scaledTitleHeight);
 		cvui::beginColumn(mWidth - std::lround(10*mFontScale/cvui::DEFAULT_FONT_SCALE), mHeight - scaledTitleHeight);
 	}
 

--- a/cvui.py
+++ b/cvui.py
@@ -59,6 +59,8 @@ OVER = 4
 OUT = 5
 UP = 6
 IS_DOWN = 7
+WHEEL_DOWN = 8
+WHEEL_UP = 9
 
 # Constants regarding mouse buttons
 LEFT_BUTTON = 0
@@ -156,11 +158,12 @@ class MouseButton:
 		self.justReleased = False           # if the mouse button was released, i.e. click event.
 		self.justPressed = False            # if the mouse button was just pressed, i.e. true for a frame when a button is down.
 		self.pressed = False                # if the mouse button is pressed or not.
-
+		self.wheel = 0
 	def reset(self):
 		self.justPressed = False
 		self.justReleased = False
 		self.pressed = False
+		self.wheel = 0
 
 # Describe the information of the mouse cursor
 class Mouse:
@@ -216,6 +219,10 @@ class Internal:
 			aRet = theButton.justPressed
 		elif theQuery == IS_DOWN:
 			aRet = theButton.pressed
+		elif theQuery == WHEEL_DOWN:
+			aRet = True if theButton.wheel < 0 else False
+		elif theQuery == WHEEL_UP:
+			aRet = True if theButton.wheel > 0 else False
 
 		return aRet
 
@@ -1034,6 +1041,13 @@ def _handleMouse(theEvent, theX, theY, theFlags, theContext):
 
 	theContext.mouse.position.x = theX
 	theContext.mouse.position.y = theY
+	#add wheel info
+	if theEvent == cv2.EVENT_MOUSEWHEEL:
+		if theFlags < 0:
+			theContext.mouse.buttons[MIDDLE_BUTTON].wheel = -1
+		elif theFlags > 0 :
+			theContext.mouse.buttons[MIDDLE_BUTTON].wheel = 1
+
 
 def init(theWindowName, theDelayWaitKey = -1, theCreateNamedWindow = True):
 	"""
@@ -2412,6 +2426,7 @@ def update(theWindowName = ''):
 	for i in range(LEFT_BUTTON, RIGHT_BUTTON + 1):
 		aContext.mouse.buttons[i].justReleased = False
 		aContext.mouse.buttons[i].justPressed  = False
+		aContext.mouse.buttons[i].wheel = 0
 
 	__internal.screen.reset()
 

--- a/docs/advanced-mouse.md
+++ b/docs/advanced-mouse.md
@@ -92,7 +92,7 @@ if (cvui::mouse(cvui::LEFT_BUTTON, cvui::CLICK)) {
 ```
 ## mouse wheel 
 Test if mouse wheel was tured up or down(for example zoom in or out of image):
-
+```cpp
 if (cvui::mouse(cvui::MIDDLE_BUTTON, cvui::WHEEL_UP)) //zoom out
 {
 	std::cout<< "Wheel tured up"<<std::endl;
@@ -101,7 +101,7 @@ if (cvui::mouse(cvui::MIDDLE_BUTTON, cvui::WHEEL_DOWN)) // zoom out
 {
 	std::cout<< "Wheel tured down"<<std::endl;
 }
-
+```
 ## Learn more
 
 Check out the [mouse](https://github.com/Dovyski/cvui/tree/master/example/src/mouse), [mouse-complex](https://github.com/Dovyski/cvui/tree/master/example/src/mouse-complex) and [mouse-complex-buttons](https://github.com/Dovyski/cvui/tree/master/example/src/mouse-complex-buttons) examples for more information about cvui's mouse API.

--- a/docs/advanced-mouse.md
+++ b/docs/advanced-mouse.md
@@ -90,6 +90,17 @@ if (cvui::mouse(cvui::LEFT_BUTTON, cvui::CLICK)) {
 	std::cout << "Left mouse button click just happened." << std::endl;
 }
 ```
+## mouse wheel 
+Test if mouse wheel was tured up or down(for example zoom in or out of image):
+
+if (cvui::mouse(cvui::MIDDLE_BUTTON, cvui::WHEEL_UP)) //zoom out
+{
+	std::cout<< "Wheel tured up"<<std::endl;
+}
+if (cvui::mouse(cvui::MIDDLE_BUTTON, cvui::WHEEL_DOWN)) // zoom out
+{
+	std::cout<< "Wheel tured down"<<std::endl;
+}
 
 ## Learn more
 

--- a/docs/advanced-mouse.md
+++ b/docs/advanced-mouse.md
@@ -102,6 +102,11 @@ if (cvui::mouse(cvui::MIDDLE_BUTTON, cvui::WHEEL_DOWN)) // zoom out
 	std::cout<< "Wheel tured down"<<std::endl;
 }
 ```
+Python
+```python
+if cvui.mouse(cvui.MIDDLE_BUTTON,cvui.WHEEL_UP):
+	cvui.text(frame,10,70,'wheel up')
+```
 ## Learn more
 
 Check out the [mouse](https://github.com/Dovyski/cvui/tree/master/example/src/mouse), [mouse-complex](https://github.com/Dovyski/cvui/tree/master/example/src/mouse-complex) and [mouse-complex-buttons](https://github.com/Dovyski/cvui/tree/master/example/src/mouse-complex-buttons) examples for more information about cvui's mouse API.


### PR DESCRIPTION
mouse wheel support was fixed to compile with opencv 2.4
only works with version 3 and above

double click support (in c++ not yet in python)

fixed bug render image with different color space from background image color space, we convert the image to background image.