### PR TITLE
Increase font parameters to support custom fonts and Unicode characters.

### DIFF
--- a/cvui.py
+++ b/cvui.py
@@ -2485,6 +2485,7 @@ def text(*theArgs):
 		aText = theArgs[0]
 		aFontScale = theArgs[1] if len(theArgs) >= 2 else 0.4
 		aColor = theArgs[2] if len(theArgs) >= 3 else 0xCECECE
+		aFont = theArgs[3] if len(theArgs) >= 4 else None
 
 	__internal.text(aBlock, aX, aY, aText, aFontScale, aColor, True, font=aFont)
 


### PR DESCRIPTION
Increase font parameters to support custom fonts and to solve the problem of cv2.putText displaying Chinese fonts garbled.

Use case:
```python
cvui.text(frame, 110, 160, 'cvui 你好!', 0.4, 0xCECECE, 'NotoSansCJK-Regular.ttc')
```