### PR TITLE
Small bugfix for potential divide by zero error during sparkline rendering.

### DIFF
--- a/cvui.py
+++ b/cvui.py
@@ -991,7 +991,8 @@ class Render:
 	def sparkline(self, theBlock, theValues, theRect, theMin, theMax, theColor):
 		aSize = len(theValues)
 		i = 0
-		aScale = theMax - theMin
+		delta = theMax - theMin
+		aScale = 1 if delta == 0 else delta
 		aGap = float(theRect.width) / aSize
 		aPosX = theRect.x
 


### PR DESCRIPTION
# Issue
Sometimes, when the **same** data is repeatedly added to a sparkline to be rendered a `ZeroDivisionError` is thrown.  
```
Traceback (most recent call last):
  File "C:\Users\adewi\acode\perspective\python\main.py", line 101, in run_face_detector
    self.draw_detection_data(detection, image_height, image_width)
  File "C:\Users\adewi\acode\perspective\python\main.py", line 66, in draw_detection_data
    self.drawer.drawSparklines(self.rawPosition[0], self.position[0])
  File "C:\Users\adewi\acode\perspective\python\drawer.py", line 97, in drawSparklines
    cvui.sparkline(
  File "C:\Users\adewi\AppData\Local\Programs\Python\Python39\lib\site-packages\cvui\cvui.py", line 2746, in sparkline
    __internal.sparkline(aBlock, aValues, aX, aY, aWidth, aHeight, aColor)
  File "C:\Users\adewi\AppData\Local\Programs\Python\Python39\lib\site-packages\cvui\cvui.py", line 637, in sparkline
    self._render.sparkline(theBlock, theValues, aRect, aMin, aMax, theColor)
  File "C:\Users\adewi\AppData\Local\Programs\Python\Python39\lib\site-packages\cvui\cvui.py", line 1000, in sparkline
    y = (theValues[i] - theMin) / aScale * -(theRect.height - 5) + theRect.y + theRect.height - 5
ZeroDivisionError: float division by zero
```

# Steps to recreate
Run this script:
```python
import cv2
import cvui
import numpy as np


CVUI_WINDOW_NAME = "CVUI"
CVUI_FRAME = np.zeros((200, 600, 3), np.uint8)
cvui.init(CVUI_WINDOW_NAME)

sparkline_data = [1.23] * 10  # populate data with all same values

while True:
    cvui.sparkline(CVUI_FRAME, sparkline_data, 0, 0, 600, 200, 0x00FF00)

    cvui.imshow(CVUI_WINDOW_NAME, CVUI_FRAME)
    k = cv2.waitKey(1) & 0xFF
    if k == 27:
        break
```

# Proposed solution
The problem can be traced to Line 1000 in [cvui.py](https://github.com/Dovyski/cvui/blob/5457a839af29bfc802b573cfab4b815667d6bf0a/cvui.py#L1000).  Specifically: when the calculated value for `aScale` becomes zero, a `ZeroDivisionError` will be thrown.  This occurs when both `theMax` and `theMin` are the same value which can be done by providing the call to `cvui.sparkline(...)` with a array of all the same values.  

The proposed fix is to either use the calculated `aScale` value (i.e. `theMax - theMin`) but if that computes to zero, use `1` instead. 